### PR TITLE
perf: true concurrency with bounded channel + semaphore, HTTP timeouts and backpressure

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -29,7 +29,7 @@ pub async fn payments(
     //Json(payload): Json<PostPayments>,
     body: Bytes,
 ) -> StatusCode {
-    match state.sender.send(body) {
+    match state.sender.try_send(body) {
         Ok(_) => StatusCode::CREATED,
         Err(_) =>  StatusCode::TOO_MANY_REQUESTS,
     }

--- a/src/domain/entities.rs
+++ b/src/domain/entities.rs
@@ -2,7 +2,7 @@ use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use axum::body::Bytes;
-use tokio::sync::mpsc::{UnboundedSender};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct HealthResponse {
@@ -21,7 +21,7 @@ pub struct HealthStatusAll {
 #[derive(Clone)]
 pub struct AppState {
     pub redis: Arc<ConnectionManager>,
-    pub sender: UnboundedSender<Bytes>
+    pub sender: Sender<Bytes>
 }
 
 #[derive(Deserialize, Serialize, Debug,Clone)]


### PR DESCRIPTION
Contexto

Durante a análise de performance para a Rinha de Backend 2025, identifiquei gargalos que serializavam o consumo da fila e permitiam backlog infinito em memória, além de chamadas HTTP sem timeout. Isso limitava a vazão e comprometia a estabilidade sob carga.

Principais mudanças

- Concorrência real de processamento
  - Substitui UnboundedSender/Mutex no receiver por mpsc bounded + Semaphore.
  - Agora há N tarefas “em voo” por instância, controladas por MAX_WORKERS.
- Backpressure no endpoint de ingestão
  - /payments usa try_send; quando a fila está cheia, responde 429 (Too Many Requests).
- Timeouts e tunings do cliente HTTP
  - reqwest com connect_timeout curto e timeout total agressivo, tcp_nodelay e pool_idle_timeout.
- Re-tentativas reduzidas e mais rápidas
  - Menos tentativas e backoff menor para falhar rápido e cair no fallback quando necessário.

Detalhes técnicos

- AppState: UnboundedSender<Bytes> -> Sender<Bytes>.
- main.rs:
  - mpsc::channel com capacidade configurável via CHANNEL_CAPACITY (default 4096).
  - Loop único que spawna tasks limitadas por Semaphore para processar as mensagens.
  - Cliente reqwest com timeouts e tunings.
- api/handlers.rs:
  - try_send no ingresso para 429 quando fila cheia.
- application/services.rs:
  - Redução de tentativas no DEFAULT e backoff; fallback ativado mais cedo.

Variáveis de ambiente novas/opcionais

- MAX_WORKERS (já existia): controla concorrência.
- CHANNEL_CAPACITY (novo, opcional): capacidade do canal para aplicar backpressure (padrão 4096).

Motivação

- A versão anterior, na prática, processava apenas uma mensagem por vez por instância devido ao Mutex envolvendo o UnboundedReceiver.
- Sem timeout nas chamadas ao processador de pagamentos, havia risco de tasks ficarem penduradas, reduzindo vazão e aumentando p95/p99.
- Fila ilimitada podia levar a OOM sob carga.

Resultados esperados

- Aumento da vazão (mais requisições em voo), menor latência tail e maior estabilidade sob picos de carga, respeitando os limites de CPU/memória da Rinha.

Notas

- Mantive mudanças mínimas na superfície pública e sem alterar rotas.
- Caso desejem, posso complementar com ajustes no HAProxy/nginx (keep-alive e simplificação do path) em PR separado.



@andersongomes001 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4ce58eece8834b44bd35720d2400290b)